### PR TITLE
Bug fixes and added features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.naspo</groupId>
     <artifactId>Tether</artifactId>
-    <version>2.6.0</version>
+    <version>2.6.1</version>
     <packaging>jar</packaging>
 
     <name>Tether</name>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>6.5.1</version>
+            <version>6.33.15</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/naspo/tether/leash/LeashPlayer.java
+++ b/src/main/java/me/naspo/tether/leash/LeashPlayer.java
@@ -13,12 +13,13 @@ import org.bukkit.event.entity.EntityUnleashEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.spigotmc.event.entity.EntityDismountEvent;
 
 public class LeashPlayer implements Listener {
 
-    private ClaimCheckManager claimCheckManager;
-    private Tether plugin;
+    private final ClaimCheckManager claimCheckManager;
+    private final Tether plugin;
 
     public LeashPlayer(Tether plugin, ClaimCheckManager claimCheckManager) {
         this.plugin = plugin;
@@ -43,7 +44,7 @@ public class LeashPlayer implements Listener {
         }
     }
 
-    private LivingEntity mob;
+//    private LivingEntity mob;
 
     public void onInteract(PlayerInteractAtEntityEvent event) {
         Player player = event.getPlayer();
@@ -60,12 +61,12 @@ public class LeashPlayer implements Listener {
             }
 
             if (clicked.getVehicle() != null) {
-                if (!(clicked.getVehicle().equals(mob))) {
+                if (!(clicked.getVehicle().hasMetadata("naspodev_tether_plugin"))) {
                     player.sendMessage(Utils.chatColor(Utils.prefix +
                             plugin.getConfig().getString("messages.cannot-leash-riding-player")));
                     return;
                 }
-                mob.setHealth(0);
+                ((LivingEntity) clicked.getVehicle()).setHealth(0);
                 return;
             }
 
@@ -94,43 +95,41 @@ public class LeashPlayer implements Listener {
             if (player.getInventory().getItemInMainHand().getType().equals(Material.LEAD)) {
                 leads = player.getInventory().getItemInMainHand().getAmount();
 
-                Bukkit.getScheduler().runTaskLater(plugin, new Runnable() {
-                    @Override
-                    public void run() {
-                        mob = (LivingEntity) world.spawnEntity(loc, EntityType.CHICKEN);
-                        mob.setInvisible(true);
-                        mob.setInvulnerable(true);
-                        mob.setSilent(true);
-                        mob.addPassenger(clicked);
-                        mob.setLeashHolder(player);
-                        if (plugin.getConfig().getBoolean("player-leash.message-on-leashed")) {
-                            if (plugin.getConfig().getBoolean("player-leash.escapable")) {
-                                clicked.sendMessage(Utils.chatColor(Utils.prefix +
-                                        plugin.getConfig().getString("messages.player-leashed-escapable")));
-                            } else {
-                                clicked.sendMessage(Utils.chatColor(Utils.prefix +
-                                        "messages.player-leashed-not-escapable"));
-                            }
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    LivingEntity mob = (LivingEntity) world.spawnEntity(loc, EntityType.CHICKEN);
+                    mob.setMetadata("naspodev_tether_plugin", new FixedMetadataValue(plugin, "_"));
+                    mob.setInvisible(true);
+                    mob.setInvulnerable(true);
+                    mob.setSilent(true);
+                    mob.addPassenger(clicked);
+                    mob.setLeashHolder(player);
+                    if (plugin.getConfig().getBoolean("player-leash.message-on-leashed")) {
+                        if (plugin.getConfig().getBoolean("player-leash.escapable")) {
+                            clicked.sendMessage(Utils.chatColor(Utils.prefix +
+                                    plugin.getConfig().getString("messages.player-leashed-escapable")));
+                        } else {
+                            clicked.sendMessage(Utils.chatColor(Utils.prefix +
+                                    "messages.player-leashed-not-escapable"));
                         }
-                        ItemStack lead = new ItemStack(Material.LEAD, 1);
-                        if (player.getInventory().getItemInMainHand().getAmount() == (leads - 1)) {
-                            return;
-                        }
-                        player.getInventory().removeItem(lead);
                     }
+                    ItemStack lead = new ItemStack(Material.LEAD, 1);
+                    if (player.getInventory().getItemInMainHand().getAmount() == (leads - 1)) {
+                        return;
+                    }
+                    player.getInventory().removeItem(lead);
                 }, 1L);
             }
         }
     }
 
     private void onDismountEscapable(EntityDismountEvent event) {
-        if (event.getDismounted().equals(mob)) {
-            mob.setHealth(0);
+        if (event.getDismounted().hasMetadata("naspodev_tether_plugin")) {
+            ((LivingEntity) event.getDismounted()).setHealth(0);
         }
     }
 
     private void onDismountNotEscapable(EntityDismountEvent event) {
-        if (event.getDismounted().equals(mob)) {
+        if (event.getDismounted().hasMetadata("naspodev_tether_plugin")) {
             event.setCancelled(true);
         }
     }
@@ -138,16 +137,17 @@ public class LeashPlayer implements Listener {
     //Kill the mob on lead break.
     @EventHandler
     private void onLeadBreak(EntityUnleashEvent event) {
-        if (event.getEntity().equals(mob)) {
-            if (mob.getHealth() > 0) {
-                mob.setHealth(0);
+        if (event.getEntity().hasMetadata("naspodev_tether_plugin")) {
+            LivingEntity entity = (LivingEntity) event.getEntity();
+            if (entity.getHealth() > 0) {
+                entity.setHealth(0);
             }
         }
     }
 
     @EventHandler
     private void onMobDeath(EntityDeathEvent event) {
-        if (event.getEntity().equals(mob)) {
+        if (event.getEntity().hasMetadata("naspodev_tether_plugin")) {
             event.getDrops().clear();
         }
     }

--- a/src/main/java/me/naspo/tether/leash/LeashPlayer.java
+++ b/src/main/java/me/naspo/tether/leash/LeashPlayer.java
@@ -78,6 +78,14 @@ public class LeashPlayer implements Listener {
             }
 
             //Leashing the player.
+            if (plugin.getConfig().getBoolean("player-leash.prevent-nesting")) {
+                if (player.getVehicle() != null) {
+                    player.sendMessage(Utils.chatColor(Utils.prefix + plugin.getConfig().getString(
+                            "messages.prevent-nesting")));
+                    return;
+                }
+            }
+
             World world = clicked.getWorld();
             Location loc = clicked.getLocation();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,7 +13,7 @@ player-leash:
   #Should players receive a message when they've been leashed? (Redundant if player-leash is false).
   message-on-leashed: true
   #If you are already riding, you can no longer tether other players, This does not affect leash mobs
-  prevent-nesting: true
+  prevent-nesting: false
 
 #Should Tether hook into the following land management plugins?
 #(Requires restart upon change).

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,8 @@ player-leash:
   escapable: true
   #Should players receive a message when they've been leashed? (Redundant if player-leash is false).
   message-on-leashed: true
+  #If you are already riding, you can no longer tether other players, This does not affect leash mobs
+  prevent-nesting: true
 
 #Should Tether hook into the following land management plugins?
 #(Requires restart upon change).
@@ -31,3 +33,4 @@ messages:
   player-leashed-escapable: "&7You've been leashed! Press &6crouch &7to escape."
   player-leashed-not-escapable: "&7You've been leashed!"
   cannot-leash-riding-player: "&7You cannot leash players that are riding an entity."
+  prevent-nesting: "&7You cannot leash a player while mounted"


### PR DESCRIPTION
- [Add prevent-nesting functionality](https://github.com/NaspoDev/Tether/commit/137581273be1a724a21d196b37b322c0f8ca02ae)
> If you are already riding, you can no longer tether other players, This does not affect leash mobs

- [fix: Entities are not being cleared properly when multiple players use a lead](https://github.com/NaspoDev/Tether/commit/fae5a9e9c72f352a86c664f58158f896d535f34d)
> Entities mounted by the first player will not be cleared if the second player leashes the player

These codes were tested on my server and worked fine :)